### PR TITLE
Update main.cpp

### DIFF
--- a/include/main.h
+++ b/include/main.h
@@ -27,7 +27,7 @@
 #include "HardwareSerial.h"
 
 #include "config.h"
-#ifndef TTGO_T_Beam_S3_SUPREME_V3
+#ifndef CONFIG_IDF_TARGET_ESP32S3
 #include "soc/rtc_wdt.h"
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3219,7 +3219,7 @@ void setup()
 
 #ifdef HELTEC_HTIT_TRACKER
     pinMode(2, OUTPUT); // ADC_Ctl
-    digitalWrite(2, HIGH);
+    //digitalWrite(2, HIGH);
 #endif
 
     // Set up serial port

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4365,13 +4365,13 @@ uint8_t led_pin = 9;
 // (i.e. an array of pointers to strings composed of dots and dashes)
 // Done to preserve memory because strings are not equal in size. A 2D array
 // would be a waste of space.
-char *letters[] = {
+const char *letters[] = {
     // The letters A-Z in Morse code
     ".-", "-...", "-.-.", "-..", ".", "..-.", "--.", "....", "..",
     ".---", "-.-", ".-..", "--", "-.", "---", ".--.", "--.-", ".-.",
     "...", "-", "..-", "...-", ".--", "-..-", "-.--", "--.."};
 
-char *numbers[] = {
+const char *numbers[] = {
     // The numbers 0-9 in Morse code
     "-----", ".----", "..---", "...--", "....-", ".....", "-....",
     "--...", "---..", "----."};
@@ -4412,13 +4412,13 @@ void flash_dot_or_dash(char dot_or_dash)
  *  Flashes the Morse code for the input letter or number
  *  @param morse_code pointer to the morse code
  */
-void flash_morse_code(char *morse_code)
+void flash_morse_code(const char *morse_code)
 {
 
     unsigned int i = 0;
 
     // Read the dots and dashes and flash accordingly
-    while (morse_code[i] != NULL)
+    while (morse_code[i] != '\0')
     {
         flash_dot_or_dash(morse_code[i]);
         i++;
@@ -5652,7 +5652,7 @@ void taskGPS(void *pvParameters)
                             setTime(timeGps);
                             time_t rtc = timeGps - (config.timeZone * SECS_PER_HOUR);
                             timeval tv = {rtc, 0};
-                            timezone tz = {(config.timeZone * SECS_PER_HOUR), 0};
+                            timezone tz = {static_cast<int>(config.timeZone * SECS_PER_HOUR), 0};
                             settimeofday(&tv, &tz);
 #ifdef DEBUG
                             log_d("\nSET GPS Timestamp = %u Year=%d\n", timeGps, year());

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -179,6 +179,11 @@ bool getBAT(uint8_t port)
                 #elif defined(BUOY)
                 VBat = (double)analogReadMilliVolts(0) / 595.24F;
                 sensorUpdate(i, VBat);
+                #elif defined(HELTEC_HTIT_TRACKER)
+                digitalWrite(2, HIGH); //ADC_Ctrl PIN 2
+                VBat = (double)analogReadMilliVolts(1) / 204.08F;  //390k/100k Voltage divider
+                sensorUpdate(i, VBat + 0.285F); //Add offset 0.285V
+                digitalWrite(2, LOW);
                 #endif
             }else if (config.sensor[i].type == SENSOR_BAT_PERCENT)
             {

--- a/src/webservice.cpp
+++ b/src/webservice.cpp
@@ -7705,6 +7705,7 @@ void handle_about(AsyncWebServerRequest *request)
 	webString += "<tr><td align=\"right\"><b>ESP32 Model: </b></td><td align=\"left\"> " + String(ESP.getChipModel()) + "</td></tr>";
 	webString += "<tr><td align=\"right\"><b>Revision: </b></td><td align=\"left\"> " + String(ESP.getChipRevision()) + "</td></tr>";
 	webString += "<tr><td align=\"right\"><b>Chip ID: </b></td><td align=\"left\"> " + String(strCID) + "</td></tr>";
+	webString += "<tr><td align=\"right\"><b>ESP32 CPU freq: </b></td><td align=\"left\"> " + String(ESP.getCpuFreqMHz()) + "</td></tr>";
 	webString += "<tr><td align=\"right\"><b>Flash: </b></td><td align=\"left\">" + String(ESP.getFlashChipSize() / 1024) + " KByte</td></tr>";
 	webString += "<tr><td align=\"right\"><b>PSRAM: </b></td><td align=\"left\">" + String((float)ESP.getFreePsram() / 1024, 1) + "/" + String((float)ESP.getPsramSize() / 1024, 1) + " KByte</td></tr>";
 	webString += "<tr><td align=\"right\"><b>FILE SYSTEM: </b></td><td align=\"left\">" + String((float)LITTLEFS.usedBytes() / 1024, 1) + "/" + String((float)LITTLEFS.totalBytes() / 1024, 1) + " KByte</td></tr>";


### PR DESCRIPTION
Fix some warnings.
- Making C++ char* constant
- Use the character '\0' instead of NULL to indicate the end of strings.
- Floating point and integer division. To avoid the warning, explicitly convert the result to int type, indicating that you are aware of the conversion and possible loss.